### PR TITLE
[MATTER-247] Enable dynamic allocation of packet buffers

### DIFF
--- a/examples/contact-sensor-app/nxp/k32w/k32w0/include/CHIPProjectConfig.h
+++ b/examples/contact-sensor-app/nxp/k32w/k32w0/include/CHIPProjectConfig.h
@@ -136,7 +136,7 @@
  *    provision the device with its unique operational credentials and manage
  *    its own access control lists.
  */
-#define CHIP_CONFIG_MAX_FABRICS 4 // 3 fabrics + 1 for rotation slack
+#define CHIP_CONFIG_MAX_FABRICS 5 // 5 is the minimum number of supported fabrics
 
 #define CHIP_DEVICE_CONFIG_ENABLE_SED 1
 #define CHIP_DEVICE_CONFIG_SED_SLOW_POLLING_INTERVAL 1000_ms32

--- a/examples/lighting-app/nxp/k32w/k32w0/include/CHIPProjectConfig.h
+++ b/examples/lighting-app/nxp/k32w/k32w0/include/CHIPProjectConfig.h
@@ -126,7 +126,7 @@
  *    provision the device with its unique operational credentials and manage
  *    its own access control lists.
  */
-#define CHIP_CONFIG_MAX_FABRICS 4 // 3 fabrics + 1 for rotation slack
+#define CHIP_CONFIG_MAX_FABRICS 5 // 5 is the minimum number of supported fabrics
 
 /**
  * @def CHIP_IM_MAX_NUM_COMMAND_HANDLER

--- a/examples/lock-app/nxp/k32w/k32w0/include/CHIPProjectConfig.h
+++ b/examples/lock-app/nxp/k32w/k32w0/include/CHIPProjectConfig.h
@@ -126,7 +126,7 @@
  *    provision the device with its unique operational credentials and manage
  *    its own access control lists.
  */
-#define CHIP_CONFIG_MAX_FABRICS 4 // 3 fabrics + 1 for rotation slack
+#define CHIP_CONFIG_MAX_FABRICS 5 // 5 is the minimum number of supported fabrics
 
 #define CHIP_DEVICE_CONFIG_ENABLE_SED 1
 #define CHIP_DEVICE_CONFIG_SED_IDLE_INTERVAL 1000_ms32

--- a/examples/platform/nxp/k32w/k32w0/app/ldscripts/chip-k32w0x-linker.ld
+++ b/examples/platform/nxp/k32w/k32w0/app/ldscripts/chip-k32w0x-linker.ld
@@ -213,9 +213,8 @@ SECTIONS
 
     _etext = .;
 
-    .heap_packet_buffer (COPY):
+    .heap (COPY):
     {
-        *(.bss._ZN4chip6System12PacketBuffer11sBufferPoolE)
         __HeapBase = .;
          _heap = .;
         KEEP(*(.heap*))

--- a/src/platform/nxp/k32w/k32w0/SystemPlatformConfig.h
+++ b/src/platform/nxp/k32w/k32w0/SystemPlatformConfig.h
@@ -37,7 +37,7 @@ struct ChipDeviceEvent;
 // ==================== Platform Adaptations ====================
 #define CHIP_SYSTEM_CONFIG_PLATFORM_PROVIDES_TIME 1
 #define CHIP_SYSTEM_CONFIG_EVENT_OBJECT_TYPE const struct ::chip::DeviceLayer::ChipDeviceEvent *
-#define CHIP_SYSTEM_CONFIG_PACKETBUFFER_POOL_SIZE 9
+#define CHIP_SYSTEM_CONFIG_PACKETBUFFER_POOL_SIZE 0
 
 // ========== Platform-specific Configuration Overrides =========
 

--- a/third_party/nxp/k32w0_sdk/k32w0_sdk.gni
+++ b/third_party/nxp/k32w0_sdk/k32w0_sdk.gni
@@ -212,7 +212,7 @@ template("k32w0_sdk") {
       "USE_SDK_OSA=0",
       "gSerialManagerMaxInterfaces_c=2",
       "FSL_RTOS_FREE_RTOS=1",
-      "gTotalHeapSize_c=0xC700",
+      "gTotalHeapSize_c=0x10000",
       "gUartDebugConsole_d=1",
       "DEBUG_SERIAL_INTERFACE_INSTANCE=0",
       "APP_SERIAL_INTERFACE_INSTANCE=1",


### PR DESCRIPTION
 * increased maximum number of fabrics supported
 * RAM1 is now entirely reserved for heap usage

Signed-off-by: Marius Tache <marius.tache@nxp.com>

#### Problem
Packet buffers were statically allocated. This was causing `PacketBuffer: empty POOL` errors in certain conditions (multi-admin and stress test of LED toggling).

#### Testing
* Tested in multi-fabric scenario, with multiple soft/factory resets.
