### PR TITLE
[K32W0] Add RamStorage wrapper over RAM operations

### DIFF
--- a/src/platform/nxp/k32w/common/RamStorage.cpp
+++ b/src/platform/nxp/k32w/common/RamStorage.cpp
@@ -1,0 +1,103 @@
+/*
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <platform/internal/CHIPDeviceLayerInternal.h>
+
+#include <platform/nxp/k32w/common/RamStorage.h>
+
+namespace chip::DeviceLayer::Internal {
+
+RamStorage::Buffer RamStorage::sBuffer = nullptr;
+
+CHIP_ERROR RamStorage::Init(uint16_t aNvmId, uint16_t aInitialSize)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    sBuffer = getRamBuffer(aNvmId, aInitialSize);
+    if (!sBuffer)
+    {
+        err = CHIP_ERROR_NO_MEMORY;
+    }
+
+    return err;
+}
+
+void RamStorage::FreeBuffer()
+{
+    if (sBuffer)
+    {
+        free(sBuffer);
+        sBuffer = nullptr;
+    }
+}
+
+CHIP_ERROR RamStorage::Read(uint16_t aKey, int aIndex, uint8_t* aValue, uint16_t* aValueLength)
+{
+    CHIP_ERROR err;
+    rsError status;
+
+    status = ramStorageGet(sBuffer, aKey, aIndex, aValue, aValueLength);
+    SuccessOrExit(err = MapStatusToChipError(status));
+
+exit:
+    return err;
+}
+
+CHIP_ERROR RamStorage::Write(uint16_t aKey, const uint8_t* aValue, uint16_t aValueLength)
+{
+    CHIP_ERROR err;
+    rsError status = RS_ERROR_NONE;
+
+    // Delete all occurences of "key" and resize buffer if needed
+    // before scheduling writing of new value.
+    ramStorageDelete(sBuffer, aKey, -1);
+    status = ramStorageResize(&sBuffer, aKey, aValue, aValueLength);
+    SuccessOrExit(err = MapStatusToChipError(status));
+    status = ramStorageSet(sBuffer, aKey, aValue, aValueLength);
+    SuccessOrExit(err = MapStatusToChipError(status));
+  
+exit:
+    return err;
+
+}
+
+CHIP_ERROR RamStorage::Delete(uint16_t aKey, int aIndex)
+{
+    rsError status = ramStorageDelete(sBuffer, aKey, aIndex);
+    return MapStatusToChipError(status);
+}
+
+CHIP_ERROR RamStorage::MapStatusToChipError(rsError rsStatus)
+{
+    CHIP_ERROR err;
+
+    switch (rsStatus)
+    {
+    case RS_ERROR_NONE:
+        err = CHIP_NO_ERROR;
+        break;
+    case RS_ERROR_NOT_FOUND:
+        err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND;
+        break;
+    default:
+        err = CHIP_ERROR_BUFFER_TOO_SMALL;
+        break;
+    }
+
+    return err;
+}
+
+}

--- a/src/platform/nxp/k32w/common/RamStorage.h
+++ b/src/platform/nxp/k32w/common/RamStorage.h
@@ -1,0 +1,54 @@
+/*
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <platform/internal/CHIPDeviceLayerInternal.h>
+
+#include "ram_storage.h"
+#include "pdm_ram_storage_glue.h"
+
+namespace chip {
+namespace DeviceLayer {
+namespace Internal {
+
+/**
+ *
+ * All ram storage operations should be managed by this class.
+ */
+class RamStorage
+{
+public:
+    using Buffer = ramBufferDescriptor*;
+
+    static CHIP_ERROR Init(uint16_t aNvmId, uint16_t aInitialSize);
+    static void FreeBuffer();
+    static Buffer GetBuffer() { return sBuffer; }
+
+    static CHIP_ERROR Read(uint16_t aKey, int aIndex, uint8_t* aValue, uint16_t* aValueLength);
+    static CHIP_ERROR Write(uint16_t aKey, const uint8_t* aValue, uint16_t aValueLength);
+    static CHIP_ERROR Delete(uint16_t aKey, int aIndex);
+
+private:
+    static CHIP_ERROR MapStatusToChipError(rsError rsStatus);
+
+    static Buffer sBuffer;
+};
+
+} // namespace Internal
+} // namespace DeviceLayer
+} // namespace chip

--- a/src/platform/nxp/k32w/k32w0/BUILD.gn
+++ b/src/platform/nxp/k32w/k32w0/BUILD.gn
@@ -26,6 +26,8 @@ static_library("k32w0") {
   sources = [
     "../../../FreeRTOS/SystemTimeSupport.cpp",
     "../../../SingletonConfigurationManager.cpp",
+    "../common/RamStorage.cpp",
+    "../common/RamStorage.h",
     "BLEManagerImpl.cpp",
     "BLEManagerImpl.h",
     "CHIPDevicePlatformConfig.h",

--- a/src/platform/nxp/k32w/k32w0/K32W0Config.cpp
+++ b/src/platform/nxp/k32w/k32w0/K32W0Config.cpp
@@ -37,27 +37,19 @@ namespace DeviceLayer {
 namespace Internal {
 
 osaMutexId_t K32WConfig::pdmMutexHandle = NULL;
-static ramBufferDescriptor * ramDescr = NULL;
-
-constexpr uint16_t kNvmIdChipConfigData  = 0x5000;
-constexpr uint16_t kRamBufferInitialSize = 3072;
 
 CHIP_ERROR K32WConfig::Init()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-    int pdmStatus;
+    int status;
 
     /* Initialise the Persistent Data Manager */
     pdmMutexHandle = OSA_MutexCreate();
     VerifyOrExit((NULL != pdmMutexHandle), err = CHIP_ERROR_NO_MEMORY);
-    pdmStatus = PDM_Init();
-    SuccessOrExit(err = MapPdmInitStatus(pdmStatus));
+    status = PDM_Init();
+    SuccessOrExit(err = MapPdmInitStatusToChipError(status));
 
-    ramDescr = getRamBuffer(kNvmIdChipConfigData, kRamBufferInitialSize);
-    if (!ramDescr)
-    {
-        err = CHIP_ERROR_NO_MEMORY;
-    }
+    err = RamStorage::Init(kNvmIdChipConfigData, kRamBufferInitialSize);
 
 exit:
     if (err != CHIP_NO_ERROR)
@@ -66,10 +58,8 @@ exit:
         {
             OSA_MutexDestroy(pdmMutexHandle);
         }
-        if (ramDescr)
-        {
-            free(ramDescr);
-        }
+        
+        RamStorage::FreeBuffer();
     }
     return err;
 }
@@ -92,65 +82,15 @@ void K32WConfig::MutexUnlock(osaMutexId_t mutexId)
     }
 }
 
-CHIP_ERROR K32WConfig::ReadConfigValue(Key key, bool & val)
-{
-    CHIP_ERROR err;
-    bool tempVal;
-    rsError status;
-    uint16_t sizeToRead = sizeof(tempVal);
-
-    VerifyOrExit(ValidConfigKey(key), err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND); // Verify key id.
-    status = ramStorageGet(ramDescr, key, 0, (uint8_t *) &tempVal, &sizeToRead);
-    SuccessOrExit(err = MapRamStorageStatus(status));
-    val = tempVal;
-
-exit:
-    return err;
-}
-
-CHIP_ERROR K32WConfig::ReadConfigValue(Key key, uint32_t & val)
-{
-    CHIP_ERROR err;
-    uint32_t tempVal;
-    rsError status;
-    uint16_t sizeToRead = sizeof(tempVal);
-
-    VerifyOrExit(ValidConfigKey(key), err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND); // Verify key id.
-    status = ramStorageGet(ramDescr, key, 0, (uint8_t *) &tempVal, &sizeToRead);
-    SuccessOrExit(err = MapRamStorageStatus(status));
-    val = tempVal;
-
-exit:
-    return err;
-}
-
-CHIP_ERROR K32WConfig::ReadConfigValue(Key key, uint64_t & val)
-{
-    CHIP_ERROR err;
-    uint32_t tempVal;
-    rsError status;
-    uint16_t sizeToRead = sizeof(tempVal);
-
-    VerifyOrExit(ValidConfigKey(key), err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND); // Verify key id.
-    status = ramStorageGet(ramDescr, key, 0, (uint8_t *) &tempVal, &sizeToRead);
-    SuccessOrExit(err = MapRamStorageStatus(status));
-    val = tempVal;
-
-exit:
-    return err;
-}
-
 CHIP_ERROR K32WConfig::ReadConfigValueStr(Key key, char * buf, size_t bufSize, size_t & outLen)
 {
     CHIP_ERROR err;
-    rsError status;
     uint16_t sizeToRead = bufSize;
 
-    VerifyOrExit(ValidConfigKey(key), err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND); // Verify key id.
+    VerifyOrExit(ValidConfigKey(key), err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND);
+    err = RamStorage::Read(key, 0, (uint8_t *) buf, &sizeToRead);
+    SuccessOrExit(err);
 
-    // We can call ramStorageGet with null pointer to only retrieve the size
-    status = ramStorageGet(ramDescr, key, 0, (uint8_t *) buf, &sizeToRead);
-    SuccessOrExit(err = MapRamStorageStatus(status));
     outLen = sizeToRead;
 
 exit:
@@ -168,162 +108,6 @@ CHIP_ERROR K32WConfig::ReadConfigValueCounter(uint8_t counterIdx, uint32_t & val
     return ReadConfigValue(key, val);
 }
 
-CHIP_ERROR K32WConfig::WriteConfigValue(Key key, bool val)
-{
-    CHIP_ERROR err;
-    PDM_teStatus pdmStatus;
-    rsError      ramStatus = RS_ERROR_NONE;
-
-    VerifyOrExit(ValidConfigKey(key), err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND); // Verify key id.
-    MutexLock(pdmMutexHandle, osaWaitForever_c);
-
-    /* first delete all occurences of "key" */
-    ramStorageDelete(ramDescr, key, -1);
-
-    /* resize RAM Buffer if needed */
-    ramStatus = ramStorageResize(&ramDescr, key, (uint8_t *) &val, sizeof(bool));
-    SuccessOrExit(err = MapRamStorageStatus(ramStatus));
-
-    /* add to RAM buffer */
-    ramStatus = ramStorageSet(ramDescr, key, (uint8_t *) &val, sizeof(bool));
-    SuccessOrExit(err = MapRamStorageStatus(ramStatus));
-
-    /* schedule flash writing */
-    pdmStatus = PDM_eSaveRecordDataInIdleTask(kNvmIdChipConfigData, ramDescr,
-                                              ramDescr->ramBufferLen + kRamDescHeaderSize);
-    SuccessOrExit(err = MapPdmStatus(pdmStatus));
-  
-exit:
-    MutexUnlock(pdmMutexHandle);
-    return err;
-}
-
-CHIP_ERROR K32WConfig::WriteConfigValueSync(Key key, bool val)
-{
-    CHIP_ERROR err;
-    PDM_teStatus pdmStatus;
-    rsError      ramStatus = RS_ERROR_NONE;
-
-    VerifyOrExit(ValidConfigKey(key), err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND); // Verify key id.
-    MutexLock(pdmMutexHandle, osaWaitForever_c);
-
-    /* first delete all occurences of "key" */
-    ramStorageDelete(ramDescr, key, -1);
-
-    /* resize RAM Buffer if needed */
-    ramStatus = ramStorageResize(&ramDescr, key, (uint8_t *) &val, sizeof(bool));
-    SuccessOrExit(err = MapRamStorageStatus(ramStatus));
-
-    /* add to RAM buffer */
-    ramStatus = ramStorageSet(ramDescr, key, (uint8_t *) &val, sizeof(bool));
-    SuccessOrExit(err = MapRamStorageStatus(ramStatus));
-
-    // Interrupts are disabled to ensure there is no context switch during the actual
-    // writing, thus avoiding race conditions.
-    OSA_InterruptDisable();
-    pdmStatus = PDM_eSaveRecordData(kNvmIdChipConfigData, ramDescr,
-                                    ramDescr->ramBufferLen + kRamDescHeaderSize);
-    OSA_InterruptEnable();
-    SuccessOrExit(err = MapPdmStatus(pdmStatus));
-
-exit:
-    MutexUnlock(pdmMutexHandle);
-    return err;
-}
-
-CHIP_ERROR K32WConfig::WriteConfigValue(Key key, uint32_t val)
-{
-    CHIP_ERROR err;
-    PDM_teStatus pdmStatus;
-    rsError      ramStatus = RS_ERROR_NONE;
-
-    VerifyOrExit(ValidConfigKey(key), err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND); // Verify key id.
-    MutexLock(pdmMutexHandle, osaWaitForever_c);
-
-    /* first delete all occurences of "key" */
-    ramStorageDelete(ramDescr, key, -1);
-
-    /* resize RAM Buffer if needed */
-    ramStatus = ramStorageResize(&ramDescr, key, (uint8_t *) &val, sizeof(uint32_t));
-    SuccessOrExit(err = MapRamStorageStatus(ramStatus));
-
-    /* add to RAM buffer */
-    ramStatus = ramStorageSet(ramDescr, key, (uint8_t *)&val, sizeof(uint32_t));
-    SuccessOrExit(err = MapRamStorageStatus(ramStatus));
-
-    /* schedule flash writing */
-    pdmStatus = PDM_eSaveRecordDataInIdleTask(kNvmIdChipConfigData, ramDescr,
-                                              ramDescr->ramBufferLen + kRamDescHeaderSize);
-    SuccessOrExit(err = MapPdmStatus(pdmStatus));
-
-exit:
-    MutexUnlock(pdmMutexHandle);
-    return err;
-}
-
-CHIP_ERROR K32WConfig::WriteConfigValueSync(Key key, uint32_t val)
-{
-    CHIP_ERROR err;
-    PDM_teStatus pdmStatus;
-    rsError      ramStatus = RS_ERROR_NONE;
-
-    VerifyOrExit(ValidConfigKey(key), err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND); // Verify key id.
-    MutexLock(pdmMutexHandle, osaWaitForever_c);
-
-    /* first delete all occurences of "key" */
-    ramStorageDelete(ramDescr, key, -1);
-
-    /* resize RAM Buffer if needed */
-    ramStatus = ramStorageResize(&ramDescr, key, (uint8_t *) &val, sizeof(uint32_t));
-    SuccessOrExit(err = MapRamStorageStatus(ramStatus));
-
-    /* add to RAM buffer */
-    ramStatus = ramStorageSet(ramDescr, key, (uint8_t *)&val, sizeof(uint32_t));
-    SuccessOrExit(err = MapRamStorageStatus(ramStatus));
-
-    // Interrupts are disabled to ensure there is no context switch during the actual
-    // writing, thus avoiding race conditions.
-    OSA_InterruptDisable();
-    pdmStatus = PDM_eSaveRecordData(kNvmIdChipConfigData, ramDescr,
-                                    ramDescr->ramBufferLen + kRamDescHeaderSize);
-    OSA_InterruptEnable();
-    SuccessOrExit(err = MapPdmStatus(pdmStatus));
-
-exit:
-    MutexUnlock(pdmMutexHandle);
-    return err;
-}
-
-CHIP_ERROR K32WConfig::WriteConfigValue(Key key, uint64_t val)
-{
-    CHIP_ERROR err;
-    PDM_teStatus pdmStatus;
-    rsError      ramStatus = RS_ERROR_NONE;
-
-    VerifyOrExit(ValidConfigKey(key), err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND); // Verify key id.
-    MutexLock(pdmMutexHandle, osaWaitForever_c);
-
-     /* first delete all occurences of "key" */
-    ramStorageDelete(ramDescr, key, -1);
-
-    /* resize RAM Buffer if needed */
-    ramStatus = ramStorageResize(&ramDescr, key, (uint8_t *) &val, sizeof(uint64_t));
-    SuccessOrExit(err = MapRamStorageStatus(ramStatus));
-
-    /* add to RAM buffer */
-    ramStatus = ramStorageSet(ramDescr, key, (uint8_t *)&val, sizeof(uint64_t));
-    SuccessOrExit(err = MapRamStorageStatus(ramStatus));
-
-    /* schedule flash writing */
-    pdmStatus = PDM_eSaveRecordDataInIdleTask(kNvmIdChipConfigData, ramDescr,
-                                              ramDescr->ramBufferLen + kRamDescHeaderSize);
-    SuccessOrExit(err = MapPdmStatus(pdmStatus));
-
-exit:
-    MutexUnlock(pdmMutexHandle);
-    return err;
-}
-
 CHIP_ERROR K32WConfig::WriteConfigValueStr(Key key, const char * str)
 {
     return WriteConfigValueStr(key, str, (str != NULL) ? strlen(str) : 0);
@@ -332,33 +116,23 @@ CHIP_ERROR K32WConfig::WriteConfigValueStr(Key key, const char * str)
 CHIP_ERROR K32WConfig::WriteConfigValueStr(Key key, const char * str, size_t strLen)
 {
     CHIP_ERROR err;
-    PDM_teStatus pdmStatus;
-    rsError      ramStatus = RS_ERROR_NONE;
+    PDM_teStatus status;
+    RamStorage::Buffer buffer;
 
-    VerifyOrExit(ValidConfigKey(key), err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND); // Verify key id.
     MutexLock(pdmMutexHandle, osaWaitForever_c);
+    VerifyOrExit(ValidConfigKey(key), err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND);
 
     if (!str)
     {
-        ramStatus = ramStorageDelete(ramDescr, key, -1);
-        SuccessOrExit(err = MapRamStorageStatus(ramStatus));
+        err = RamStorage::Delete(key, -1);
     }
     else
     {
-        /* first delete all occurences of "key" */
-        ramStorageDelete(ramDescr, key, -1);
-
-        /* resize RAM Buffer if needed */
-        ramStatus = ramStorageResize(&ramDescr, key, (uint8_t *) str, strLen);
-        SuccessOrExit(err = MapRamStorageStatus(ramStatus));
-
-        /* add to RAM buffer */
-        ramStatus = ramStorageSet(ramDescr, key, (uint8_t *) str, strLen);
-        SuccessOrExit(err = MapRamStorageStatus(ramStatus));
-
-        /* schedule flash writing */
-        pdmStatus = PDM_eSaveRecordDataInIdleTask(kNvmIdChipConfigData, ramDescr,
-                                             ramDescr->ramBufferLen + kRamDescHeaderSize);
+        err = RamStorage::Write(key, (uint8_t *) str, strLen);
+        SuccessOrExit(err);
+        buffer = RamStorage::GetBuffer();
+        status = PDM_eSaveRecordDataInIdleTask(kNvmIdChipConfigData, buffer,
+                                               buffer->ramBufferLen + kRamDescHeaderSize);
     }
 
 exit:
@@ -380,17 +154,18 @@ CHIP_ERROR K32WConfig::WriteConfigValueCounter(uint8_t counterIdx, uint32_t val)
 CHIP_ERROR K32WConfig::ClearConfigValue(Key key)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-    rsError status;
-    PDM_teStatus pdmStatus;
+    PDM_teStatus status;
+    RamStorage::Buffer buffer;
 
-    VerifyOrExit(ValidConfigKey(key), err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND); // Verify key id.
     MutexLock(pdmMutexHandle, osaWaitForever_c);
-    status = ramStorageDelete(ramDescr, key, -1);
-    SuccessOrExit(err = MapRamStorageStatus(status));
+    VerifyOrExit(ValidConfigKey(key), err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND); // Verify key id.
+    err = RamStorage::Delete(key, -1);
+    SuccessOrExit(err);
 
-    pdmStatus =
-        PDM_eSaveRecordDataInIdleTask(kNvmIdChipConfigData, ramDescr, ramDescr->ramBufferLen + kRamDescHeaderSize);
-    SuccessOrExit(err = MapPdmStatus(pdmStatus));
+    buffer = RamStorage::GetBuffer();
+    status =
+        PDM_eSaveRecordDataInIdleTask(kNvmIdChipConfigData, buffer, buffer->ramBufferLen + kRamDescHeaderSize);
+    SuccessOrExit(err = MapPdmStatusToChipError(status));
 
 exit:
     MutexUnlock(pdmMutexHandle);
@@ -399,22 +174,25 @@ exit:
 
 bool K32WConfig::ConfigValueExists(Key key)
 {
-    rsError status;
+    CHIP_ERROR err;
     uint16_t sizeToRead;
     bool found = false;
 
     if (ValidConfigKey(key))
     {
-        status = ramStorageGet(ramDescr, key, 0, NULL, &sizeToRead);
-        found  = (status == RS_ERROR_NONE && sizeToRead != 0);
+        err = RamStorage::Read(key, 0, NULL, &sizeToRead);
+        found = (err == CHIP_NO_ERROR && sizeToRead != 0);
     }
+
+
     return found;
 }
 
 CHIP_ERROR K32WConfig::FactoryResetConfig(void)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-    PDM_teStatus pdmStatus;
+    PDM_teStatus status;
+    RamStorage::Buffer buffer;
 
     MutexLock(pdmMutexHandle, osaWaitForever_c);
     FactoryResetConfigInternal(kMinConfigKey_ChipCounter,kMaxConfigKey_ChipCounter);
@@ -422,12 +200,12 @@ CHIP_ERROR K32WConfig::FactoryResetConfig(void)
     FactoryResetConfigInternal(kMinConfigKey_KVSKey, kMaxConfigKey_KVSKey);
     FactoryResetConfigInternal(kMinConfigKey_KVSValue, kMaxConfigKey_KVSValue);
 
-    pdmStatus = PDM_eSaveRecordData(kNvmIdChipConfigData, ramDescr, ramDescr->ramBufferLen + kRamDescHeaderSize);
-    SuccessOrExit(err = MapPdmStatus(pdmStatus));
+    buffer = RamStorage::GetBuffer();
+    status = PDM_eSaveRecordData(kNvmIdChipConfigData, buffer, buffer->ramBufferLen + kRamDescHeaderSize);
+    SuccessOrExit(err = MapPdmStatusToChipError(status));
 
 exit:
-    free((void*)ramDescr);
-    ramDescr = NULL;
+    RamStorage::FreeBuffer();
     MutexUnlock(pdmMutexHandle);
     return err;
 }
@@ -436,50 +214,30 @@ void K32WConfig::FactoryResetConfigInternal(Key firstKey, Key lastKey)
 {
     for (Key key = firstKey; key <= lastKey; key++)
     {
-        ramStorageDelete(ramDescr, key, -1);
+        RamStorage::Delete(key, -1);
     }
 }
 
-CHIP_ERROR K32WConfig::MapPdmStatus(PDM_teStatus pdmStatus)
+CHIP_ERROR K32WConfig::MapPdmStatusToChipError(PDM_teStatus status)
 {
     CHIP_ERROR err;
 
-    switch (pdmStatus)
+    switch (status)
     {
     case PDM_E_STATUS_OK:
         err = CHIP_NO_ERROR;
         break;
     default:
-        err = CHIP_ERROR(ChipError::Range::kPlatform, pdmStatus);
+        err = CHIP_ERROR(ChipError::Range::kPlatform, status);
         break;
     }
 
     return err;
 }
 
-CHIP_ERROR K32WConfig::MapRamStorageStatus(rsError rsStatus)
+CHIP_ERROR K32WConfig::MapPdmInitStatusToChipError(int status)
 {
-    CHIP_ERROR err;
-
-    switch (rsStatus)
-    {
-    case RS_ERROR_NONE:
-        err = CHIP_NO_ERROR;
-        break;
-    case RS_ERROR_NOT_FOUND:
-        err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND;
-        break;
-    default:
-        err = CHIP_ERROR_BUFFER_TOO_SMALL;
-        break;
-    }
-
-    return err;
-}
-
-CHIP_ERROR K32WConfig::MapPdmInitStatus(int pdmStatus)
-{
-    return (pdmStatus == 0) ? CHIP_NO_ERROR : CHIP_ERROR(ChipError::Range::kPlatform, pdmStatus);
+    return (status == 0) ? CHIP_NO_ERROR : CHIP_ERROR(ChipError::Range::kPlatform, status);
 }
 
 bool K32WConfig::ValidConfigKey(Key key)

--- a/src/platform/nxp/k32w/k32w0/K32W0Config.h
+++ b/src/platform/nxp/k32w/k32w0/K32W0Config.h
@@ -16,26 +16,22 @@
  *    limitations under the License.
  */
 
-/**
- *    @file
- *          Utilities for accessing persisted device configuration on
- *          platforms based on the NXP K32W SDK.
- */
-
 #pragma once
 
 #include <functional>
 
 #include <platform/internal/CHIPDeviceLayerInternal.h>
 
+#include <platform/nxp/k32w/common/RamStorage.h>
 #include "PDM.h"
-#include "ram_storage.h"
-#include "pdm_ram_storage_glue.h"
 #include "fsl_os_abstraction.h"
 
 namespace chip {
 namespace DeviceLayer {
 namespace Internal {
+
+constexpr uint16_t kNvmIdChipConfigData  = 0x5000;
+constexpr uint16_t kRamBufferInitialSize = 3072;
 
 constexpr inline uint16_t K32WConfigKey(uint8_t chipId, uint8_t pdmId)
 {
@@ -117,17 +113,16 @@ public:
     static CHIP_ERROR Init(void);
 
     // Configuration methods used by the GenericConfigurationManagerImpl<> template.
-    static CHIP_ERROR ReadConfigValue(Key key, bool & val);
-    static CHIP_ERROR ReadConfigValue(Key key, uint32_t & val);
-    static CHIP_ERROR ReadConfigValue(Key key, uint64_t & val);
+    template <typename TValue>
+    static CHIP_ERROR ReadConfigValue(Key key, TValue val);
+    template <typename TValue>
+    static CHIP_ERROR WriteConfigValue(Key key, TValue val);
+    template <typename TValue>
+    static CHIP_ERROR WriteConfigValueSync(Key key, TValue val);
+
     static CHIP_ERROR ReadConfigValueStr(Key key, char * buf, size_t bufSize, size_t & outLen);
     static CHIP_ERROR ReadConfigValueBin(Key key, uint8_t * buf, size_t bufSize, size_t & outLen);
     static CHIP_ERROR ReadConfigValueCounter(uint8_t counterIdx, uint32_t & val);
-    static CHIP_ERROR WriteConfigValue(Key key, bool val);
-    static CHIP_ERROR WriteConfigValueSync(Key key, bool val);
-    static CHIP_ERROR WriteConfigValue(Key key, uint32_t val);
-    static CHIP_ERROR WriteConfigValueSync(Key key, uint32_t val);
-    static CHIP_ERROR WriteConfigValue(Key key, uint64_t val);
     static CHIP_ERROR WriteConfigValueStr(Key key, const char * str);
     static CHIP_ERROR WriteConfigValueStr(Key key, const char * str, size_t strLen);
     static CHIP_ERROR WriteConfigValueBin(Key key, const uint8_t * data, size_t dataLen);
@@ -150,9 +145,8 @@ protected:
     static constexpr uint8_t GetRecordKey(uint32_t key);
 
 private:
-    static CHIP_ERROR MapPdmStatus(PDM_teStatus pdmStatus);
-    static CHIP_ERROR MapRamStorageStatus(rsError rsStatus);
-    static CHIP_ERROR MapPdmInitStatus(int pdmStatus);
+    static CHIP_ERROR MapPdmStatusToChipError(PDM_teStatus status);
+    static CHIP_ERROR MapPdmInitStatusToChipError(int status);
     static void FactoryResetConfigInternal(Key firstKey, Key lastKey);
 };
 
@@ -170,6 +164,69 @@ inline constexpr uint8_t K32WConfig::GetPDMId(Key key)
 inline constexpr uint8_t K32WConfig::GetRecordKey(Key key)
 {
     return static_cast<uint8_t>(key);
+}
+
+template <typename TValue>
+CHIP_ERROR K32WConfig::ReadConfigValue(Key key, TValue val)
+{
+    CHIP_ERROR err;
+    TValue tempVal;
+    uint16_t sizeToRead = sizeof(tempVal);
+
+    VerifyOrExit(ValidConfigKey(key), err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND);
+    err = RamStorage::Read(key, 0, (uint8_t*)&tempVal, &sizeToRead);
+    SuccessOrExit(err);
+    val = tempVal;
+
+exit:
+    return err;
+}
+
+template <typename TValue>
+CHIP_ERROR K32WConfig::WriteConfigValue(Key key, TValue val)
+{
+    CHIP_ERROR err;
+    PDM_teStatus status;
+    RamStorage::Buffer buffer;
+
+    MutexLock(pdmMutexHandle, osaWaitForever_c);
+    VerifyOrExit(ValidConfigKey(key), err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND);
+    err = RamStorage::Write(key, (uint8_t*)&val, sizeof(TValue));
+    SuccessOrExit(err);
+
+    buffer = RamStorage::GetBuffer();
+    status = PDM_eSaveRecordDataInIdleTask(kNvmIdChipConfigData, buffer,
+                                           buffer->ramBufferLen + kRamDescHeaderSize);
+    SuccessOrExit(err = MapPdmStatusToChipError(status));
+  
+exit:
+    MutexUnlock(pdmMutexHandle);
+    return err;
+}
+
+template <typename TValue>
+CHIP_ERROR K32WConfig::WriteConfigValueSync(Key key, TValue val)
+{
+    CHIP_ERROR err;
+    PDM_teStatus status;
+    RamStorage::Buffer buffer;
+
+    MutexLock(pdmMutexHandle, osaWaitForever_c);
+    VerifyOrExit(ValidConfigKey(key), err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND);
+    err = RamStorage::Write(key, (uint8_t*)&val, sizeof(TValue));
+    SuccessOrExit(err);
+    // Interrupts are disabled to ensure there is no context switch during the actual
+    // writing, thus avoiding race conditions.
+    OSA_InterruptDisable();
+    buffer = RamStorage::GetBuffer();
+    status = PDM_eSaveRecordData(kNvmIdChipConfigData, buffer,
+                                 buffer->ramBufferLen + kRamDescHeaderSize);
+    OSA_InterruptEnable();
+    SuccessOrExit(err = MapPdmStatusToChipError(status));
+  
+exit:
+    MutexUnlock(pdmMutexHandle);
+    return err;
 }
 
 } // namespace Internal


### PR DESCRIPTION
#### Problem
K32WConfig contained a lot of duplicated code.

#### Change overview
* Created a RamStorage class that should manage all RAM operations. K32WConfig uses RamStorage to update the buffer that will be written by PDM.
* Created template methods for PDM read/write. Previous code duplicated the same function for different data types.

#### Testing
Tested commissioning and reading attributes.
To be tested: OTA and multi-admin
