### PR TITLE
Fix OnOff attribute persistence over hw reset

### DIFF
--- a/examples/lighting-app/nxp/k32w/k32w0/main/AppTask.cpp
+++ b/examples/lighting-app/nxp/k32w/k32w0/main/AppTask.cpp
@@ -497,6 +497,8 @@ void AppTask::LightActionEventHandler(AppEvent * aEvent)
     }
     else if (aEvent->Type == AppEvent::kEventType_Button)
     {
+        actor = AppEvent::kEventType_Button;
+
         if (LightingMgr().IsTurnedOff())
         {
             action = LightingManager::TURNON_ACTION;
@@ -911,6 +913,7 @@ void AppTask::UpdateDeviceStateInternal(intptr_t arg)
 
     /* set the device state */
     sLightLED.Set(onoffAttrValue);
+    LightingMgr().SetState(onoffAttrValue);
 }
 
 extern "C" void OTAIdleActivities(void)

--- a/examples/lighting-app/nxp/k32w/k32w0/main/LightingManager.cpp
+++ b/examples/lighting-app/nxp/k32w/k32w0/main/LightingManager.cpp
@@ -39,6 +39,11 @@ void LightingManager::SetCallbacks(Callback_fn_initiated aActionInitiated_CB, Ca
     mActionCompleted_CB = aActionCompleted_CB;
 }
 
+void LightingManager::SetState(bool state)
+{
+	mState = state ? kState_On : kState_Off;
+}
+
 bool LightingManager::IsTurnedOff()
 {
     return (mState == kState_Off) ? true : false;

--- a/examples/lighting-app/nxp/k32w/k32w0/main/ZclCallbacks.cpp
+++ b/examples/lighting-app/nxp/k32w/k32w0/main/ZclCallbacks.cpp
@@ -68,23 +68,3 @@ void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & 
         ChipLogProgress(Zcl, "Unknown attribute ID: " ChipLogFormatMEI, ChipLogValueMEI(path.mAttributeId));
     }
 }
-
-/** @brief OnOff Cluster Init
- *
- * This function is called when a specific cluster is initialized. It gives the
- * application an opportunity to take care of cluster initialization procedures.
- * It is called exactly once for each endpoint where cluster is present.
- *
- * @param endpoint   Ver.: always
- *
- * TODO Issue #3841
- * emberAfOnOffClusterInitCallback happens before the stack initialize the cluster
- * attributes to the default value.
- * The logic here expects something similar to the deprecated Plugins callback
- * emberAfPluginOnOffClusterServerPostInitCallback.
- *
- */
-void emberAfOnOffClusterInitCallback(EndpointId endpoint)
-{
-    GetAppTask().UpdateClusterState();
-}

--- a/examples/lighting-app/nxp/k32w/k32w0/main/include/AppEvent.h
+++ b/examples/lighting-app/nxp/k32w/k32w0/main/include/AppEvent.h
@@ -25,7 +25,8 @@ struct AppEvent
 {
     enum AppEventTypes
     {
-        kEventType_Button = 0,
+        kEventType_None = 0,
+        kEventType_Button,
         kEventType_Timer,
         kEventType_TurnOn,
         kEventType_Install,

--- a/examples/lighting-app/nxp/k32w/k32w0/main/include/LightingManager.h
+++ b/examples/lighting-app/nxp/k32w/k32w0/main/include/LightingManager.h
@@ -50,6 +50,7 @@ public:
     typedef void (*Callback_fn_initiated)(Action_t, int32_t aActor);
     typedef void (*Callback_fn_completed)(Action_t);
     void SetCallbacks(Callback_fn_initiated aActionInitiated_CB, Callback_fn_completed aActionCompleted_CB);
+    void SetState(bool state);
 
 private:
     friend LightingManager & LightingMgr(void);


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:

The issue is that the internal state of the LightingManager is out-of-sync with the OnOff attribute from the cluster.

The behavior is the following:

Set OnOff attribute to Off. The Off value is saved correctly in NVM.
Hardware reset.
[emberAfOnOffClusterInitCallback](https://github.com/NXPmicro/matter/blob/SVE2/development/examples/lighting-app/nxp/k32w/k32w0/main/ZclCallbacks.cpp#L89) will be called before cluster initialization and will schedule [UpdateClusterStateInternal](https://github.com/NXPmicro/matter/blob/8c284d3fbd97773934281ffdc455587ed0d250e9/examples/lighting-app/nxp/k32w/k32w0/main/AppTask.cpp#L887).
[The clusters](https://github.com/NXPmicro/matter/blob/8c284d3fbd97773934281ffdc455587ed0d250e9/examples/lighting-app/nxp/k32w/k32w0/main/AppTask.cpp#L138) are initialized, the OnOff value is retrieved correctly from NVM
Lighting manager [is initialized](https://github.com/NXPmicro/matter/blob/8c284d3fbd97773934281ffdc455587ed0d250e9/examples/lighting-app/nxp/k32w/k32w0/main/AppTask.cpp#L167) with the [internal state always on](https://github.com/NXPmicro/matter/blob/SVE2/development/examples/lighting-app/nxp/k32w/k32w0/main/LightingManager.cpp#L31). 
UpdateClusterStateInternal is called, [this condition](https://github.com/NXPmicro/matter/blob/8c284d3fbd97773934281ffdc455587ed0d250e9/examples/lighting-app/nxp/k32w/k32w0/main/AppTask.cpp#L889) will be true (since LightingManager internal state is On) and it will write the OnOff value to On even though the one retrieved from NVM is Off.

#### Change overview

* Fixed out-of-sync behavior between OnOff attribute and LightingManager internal state by setting this internal state on init with the value received from OnOff attribute.
* Removed problematic callback that caused this overwriting of the attribute.
* Changed events number because an unnecessary OnOff attribute write was done on each OnOff cluster post attibute change. This was because the button event was called each time (event 0).
* Added SetState method for LightingManager class 

#### Testing
* Manual testing with chip-tool, tested as many scenarios as possible.
* TC-OO-2.4
